### PR TITLE
Issue #39 - fix deprecated code

### DIFF
--- a/includes/class-ipq-actions.php
+++ b/includes/class-ipq-actions.php
@@ -69,7 +69,7 @@ class IPQ_Actions {
 			return;
 		}
 		
-		if( $product->product_type == 'grouped' )
+		if( $product->get_type() == 'grouped' )
 			return;
 		
 		$settings = get_option( 'ipq_options' );

--- a/includes/class-ipq-filters.php
+++ b/includes/class-ipq-filters.php
@@ -28,7 +28,7 @@ class IPQ_Filters {
 	public function input_min_value( $default, $product ) {
 
 		// Return Defaults if it isn't a simple product 
-		if( $product->product_type != 'simple' ) {
+		if( $product->get_type() != 'simple' ) {
 			return $default;
 		}
 		
@@ -55,9 +55,9 @@ class IPQ_Filters {
 	*
 	*/	
 	public function input_max_value( $default, $product ) {	
-		
+	
 		// Return Defaults if it isn't a simple product
-		if( $product->product_type != 'simple' ) {
+		if( $product->get_type() != 'simple' ) {
 			return $default;
 		}
 		
@@ -87,7 +87,7 @@ class IPQ_Filters {
 	public function input_step_value( $default, $product ) {
 		
 		// Return Defaults if it isn't a simple product
-		if( $product->product_type != 'simple' ) {
+		if( $product->get_type() != 'simple' ) {
 			return $default;
 		}
 		
@@ -119,7 +119,7 @@ class IPQ_Filters {
 		// Return Defaults if it isn't a simple product
 		/* Commented out to allow for grouped and variable products
 		*  on their product pages
-		if( $product->product_type != 'simple' ) {
+		if( $product->get_type() != 'simple' ) {
 			return $args;
 		}
 		*/

--- a/includes/class-ipq-product-meta-box.php
+++ b/includes/class-ipq-product-meta-box.php
@@ -22,7 +22,7 @@ class IPQ_Quantity_Meta_Boxes {
 			$product = get_product( $post->ID );
 			$unsupported_product_types = array( 'external', 'grouped' );
 
-			if ( ! in_array( $product->product_type, $unsupported_product_types ) ) {
+			if ( ! in_array( $product->get_type(), $unsupported_product_types ) ) {
 						
 				add_meta_box(
 					'wpbo_product_info', 

--- a/includes/class-ipq-product-meta-box.php
+++ b/includes/class-ipq-product-meta-box.php
@@ -19,7 +19,7 @@ class IPQ_Quantity_Meta_Boxes {
 
 		if ( $post->post_type == 'product' ) {
 			
-			$product = get_product( $post->ID );
+			$product = wc_get_product( $post->ID );
 			$unsupported_product_types = array( 'external', 'grouped' );
 
 			if ( ! in_array( $product->get_type(), $unsupported_product_types ) ) {
@@ -45,7 +45,7 @@ class IPQ_Quantity_Meta_Boxes {
 		global $wp_roles;
 				
 		// Get the product and see what rules are being applied
-		$pro = get_product( $post );
+		$pro = wc_get_product( $post );
 		
 		// Get applied rules by user role
 		$roles = $wp_roles->get_names();

--- a/includes/ipq-functions.php
+++ b/includes/ipq-functions.php
@@ -13,10 +13,10 @@ function wpbo_get_applied_rule( $product, $role = null ) {
 	// Check for site wide rule
 	$options = get_option( 'ipq_options' );
 	
-	if ( get_post_meta( $product->id, '_wpbo_deactive', true ) == 'on' ) {
+	if ( get_post_meta( $product->get_id(), '_wpbo_deactive', true ) == 'on' ) {
 		return 'inactive';
 		
-	} elseif ( get_post_meta( $product->id, '_wpbo_override', true ) == 'on' ) {
+	} elseif ( get_post_meta( $product->get_id(), '_wpbo_override', true ) == 'on' ) {
 		return 'override';
 	
 	} elseif ( isset( $options['ipq_site_rule_active'] ) and $options['ipq_site_rule_active'] == 'on' ) {
@@ -38,8 +38,8 @@ function wpbo_get_applied_rule( $product, $role = null ) {
 function wpbo_get_applied_rule_obj( $product, $role = null ) {
 
 	// Get Product Terms
-	$product_cats = wp_get_post_terms( $product->id, 'product_cat' );
-	$product_tags = wp_get_post_terms( $product->id, 'product_tag' );	
+	$product_cats = wp_get_post_terms( $product->get_id(), 'product_cat' );
+	$product_tags = wp_get_post_terms( $product->get_id(), 'product_tag' );	
 
 	// Get role if not passed
 	if(!is_user_logged_in()) {
@@ -180,13 +180,13 @@ function wpbo_get_value_from_rule( $type, $product, $rule ) {
 			// Return Out of Stock values if they exist
 			switch ( $type ) {
 				case 'min':
-					$min_oos = get_post_meta( $product->id, '_wpbo_minimum_oos', true );
+					$min_oos = get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true );
 					if ( $min_oos != '' )
 						return $min_oos;
 					break;
 				
 				case 'max':
-					$max_oos = get_post_meta( $product->id, '_wpbo_maximum_oos', true );
+					$max_oos = get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true );
 					if ( $max_oos != '' )
 						return $max_oos;
 					break;	
@@ -197,31 +197,31 @@ function wpbo_get_value_from_rule( $type, $product, $rule ) {
 		switch ( $type ) {
 			case 'all':
 				return array( 
-						'min_value' => get_post_meta( $product->id, '_wpbo_minimum', true ),
-						'max_value' => get_post_meta( $product->id, '_wpbo_maximum', true ),
-						'step' 		=> get_post_meta( $product->id, '_wpbo_step', true ),
-						'min_oos'	=> get_post_meta( $product->id, '_wpbo_minimum_oos', true ),
-						'max_oos'	=> get_post_meta( $product->id, '_wpbo_maximum_oos', true ),
+						'min_value' => get_post_meta( $product->get_id(), '_wpbo_minimum', true ),
+						'max_value' => get_post_meta( $product->get_id(), '_wpbo_maximum', true ),
+						'step' 		=> get_post_meta( $product->get_id(), '_wpbo_step', true ),
+						'min_oos'	=> get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true ),
+						'max_oos'	=> get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true ),
 					);
 				break;
 			case 'min':
-				return get_post_meta( $product->id, '_wpbo_minimum', true );
+				return get_post_meta( $product->get_id(), '_wpbo_minimum', true );
 				break;
 			
 			case 'max': 
-				return get_post_meta( $product->id, '_wpbo_maximum', true );
+				return get_post_meta( $product->get_id(), '_wpbo_maximum', true );
 				break;
 				
 			case 'step':
-				return get_post_meta( $product->id, '_wpbo_step', true );
+				return get_post_meta( $product->get_id(), '_wpbo_step', true );
 				break;
 			
 			case 'min_oos':
-				return get_post_meta( $product->id, '_wpbo_minimum_oos', true );
+				return get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true );
 				break;
 			
 			case 'max_oos':
-				return get_post_meta( $product->id, '_wpbo_maximum_oos', true );
+				return get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true );
 				break;
 				
 			case 'priority':

--- a/incremental-product-quantities.php
+++ b/incremental-product-quantities.php
@@ -177,7 +177,7 @@ class Incremental_Product_Quantities {
 			if ( ! is_cart() ) {
 				
 				// Get the product
-				$pro = get_product( $post );
+				$pro = wc_get_product( $post );
 				
 				// Check if variable
 				if ( $pro->product_type == 'variable' ) {

--- a/incremental-product-quantities.php
+++ b/incremental-product-quantities.php
@@ -180,7 +180,7 @@ class Incremental_Product_Quantities {
 				$pro = wc_get_product( $post );
 				
 				// Check if variable
-				if ( $pro->product_type == 'variable' ) {
+				if ( $pro->get_type() == 'variable' ) {
 
 					// See what rules are being applied
 					$rule_result = wpbo_get_applied_rule( $pro );


### PR DESCRIPTION
Change instances of deprecated code to supported version for WooCommerce 3.4.5 to avoid a series of Notices issued since WooCommerce 3.0


From | To
----- | -----
get_product() | wc_get_product()
$product->product_type | $product->get_type()
$product->id | $product->get_id()

